### PR TITLE
Fixed misspell in kernel/arch/x86/drivers/pci.cpp

### DIFF
--- a/kernel/arch/x86/drivers/pci.cpp
+++ b/kernel/arch/x86/drivers/pci.cpp
@@ -78,7 +78,7 @@ static generic_pciHeader_t readGenericHeader(uint8_t bus, uint8_t slot, uint8_t 
      * +----------+--------+----------+------------+--------------+---------------+
      * | Register | Offset | Byte3    | Byte2      | Byte1        | Byte0         |
      * +----------+--------+----------+------------+--------------+---------------+
-     * | 0x0      | 0x0    |      deviceID         |           vedorID            |
+     * | 0x0      | 0x0    |      deviceID         |           vendorID           |
      * | 0x1      | 0x4    |       status          |           command            |
      * | 0x2      | 0x8    | classID  | subclass   | progIF       | revisionID    |
      * | 0x3      | 0xC    | BIST     | headerType | latencyTimer | cacheLineSize |


### PR DESCRIPTION
Changed comment "vedorID" to "vendorID"
I just saw this while skimming over this as an example for what to do. 👍